### PR TITLE
feat(rabbitmq): Auto-enable delayed message exchange plugin

### DIFF
--- a/Formula/rabbitmq_delayed_message_exchange.rb
+++ b/Formula/rabbitmq_delayed_message_exchange.rb
@@ -14,4 +14,18 @@ class RabbitmqDelayedMessageExchange < Formula
   def post_install
     system "rabbitmq-plugins", "enable", "--offline", "rabbitmq_delayed_message_exchange"
   end
+
+  test do
+    ENV["CONF_ENV_FILE"] = "#{HOMEBREW_PREFIX}/etc/rabbitmq/rabbitmq-env.conf"
+    ENV["RABBITMQ_MNESIA_BASE"] = testpath/"var/lib/rabbitmq/mnesia"
+
+    pid = fork { exec "#{HOMEBREW_PREFIX}/sbin/rabbitmq-server" }
+
+    system "#{HOMEBREW_PREFIX}/sbin/rabbitmq-diagnostics", "wait", "--pid", pid
+
+    enabled_plugins = shell_output "rabbitmq-plugins list --enabled"
+    assert_match(/rabbitmq_delayed_message_exchange/, enabled_plugins)
+
+    system "#{HOMEBREW_PREFIX}/sbin/rabbitmqctl", "stop"
+  end
 end

--- a/Formula/rabbitmq_delayed_message_exchange.rb
+++ b/Formula/rabbitmq_delayed_message_exchange.rb
@@ -11,13 +11,7 @@ class RabbitmqDelayedMessageExchange < Formula
     (share/"rabbitmq/plugins").install "rabbitmq_delayed_message_exchange-3.11.1.ez"
   end
 
-  def caveats
-    <<~EOS
-      This formula is unable to enable the plugin automatically.
-      Ensure rabbitmq is running, then enable the plugin:
-
-      brew services start rabbitmq
-      rabbitmq-plugins enable rabbitmq_delayed_message_exchange
-    EOS
+  def post_install
+    system "rabbitmq-plugins", "enable", "--offline", "rabbitmq_delayed_message_exchange"
   end
 end


### PR DESCRIPTION
Turns out there is an undocumented `post_install` method.
This seems to work.

Also adds back testing, now the plugin is enabled.