### PR TITLE
fix(rabbitmq): bump rabbitmq_delayed_message_exchange to 3.12.0

### DIFF
--- a/Formula/rabbitmq_delayed_message_exchange.rb
+++ b/Formula/rabbitmq_delayed_message_exchange.rb
@@ -8,7 +8,7 @@ class RabbitmqDelayedMessageExchange < Formula
   depends_on "rabbitmq"
 
   def install
-    (share/"rabbitmq/plugins").install "rabbitmq_delayed_message_exchange-3.11.1.ez"
+    (share/"rabbitmq/plugins").install "rabbitmq_delayed_message_exchange-3.12.0.ez"
   end
 
   def post_install


### PR DESCRIPTION
bump `.ez` file to 3.12.0 so it is compatible with rabbitmq 3.12.0.
[this issue](https://github.com/PlayerData/roadmap/issues/607) is tracking the problem with the renovate config and CI.

Smoke Tests:
- [x] Manually downloading the 3.12.0 binary and moving it to `/opt/homebrew/share/rabbitmq/plugins` fixes the issue