### PR TITLE
fix: Reverting to EZ instead of source

### DIFF
--- a/Formula/rabbitmq_delayed_message_exchange.rb
+++ b/Formula/rabbitmq_delayed_message_exchange.rb
@@ -1,8 +1,8 @@
 class RabbitmqDelayedMessageExchange < Formula
   desc "RabbitMQ Delayed Message Plugin"
   homepage "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange"
-  url "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/archive/v3.12.0.tar.gz"
-  sha256 "af58be85af0299fc630d776e7a98400f4805a326e703c04089aa67b214180d87"
+  url "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.12.0/rabbitmq_delayed_message_exchange-3.12.0.ez"
+  sha256 "47e5d1a959c71ed0b70b5b32fa57ca9dff6e75541528a1038b92d3af2bdf46b9"
   license "MPL-2.0"
 
   depends_on "rabbitmq"


### PR DESCRIPTION
The new dev starter scripts are expecting the brew to have the ez file instead of the tar.gz with the sourcecode.